### PR TITLE
chore: update semantic release in workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
       
       - name: Analyze commits with semantic-release
         id: semantic-release
-        uses: semantic-release/semantic-release@v21
+        uses: semantic-release/semantic-release@v24
         with:
           dry_run: true
           branches: |


### PR DESCRIPTION
This pull request updates the version of the `semantic-release` action used in the GitHub Actions workflow configuration file. 

Workflow configuration update:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L67-R67): Updated the `semantic-release` action from version `v21` to `v24` to ensure compatibility with the latest features and fixes.