### PR TITLE
chore: update semantic release in workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,13 +64,22 @@ jobs:
       
       - name: Analyze commits with semantic-release
         id: semantic-release
-        uses: semantic-release/semantic-release@v24
-        with:
-          dry_run: true
-          branches: |
-            [
-              'main'
-            ]
+        run: |
+          # Install semantic-release
+          npm install -g semantic-release@^23.0.0
+          
+          # Run semantic-release in dry-run mode
+          semantic-release --dry-run --branches main > semantic-release-output.txt || true
+          
+          # Extract version information
+          NEW_VERSION=$(grep -o "The next release version is [0-9]\+\.[0-9]\+\.[0-9]\+" semantic-release-output.txt | sed 's/The next release version is //')
+          LAST_VERSION=$(grep -o "The last release version was [0-9]\+\.[0-9]\+\.[0-9]\+" semantic-release-output.txt | sed 's/The last release version was //')
+          
+          # Set outputs
+          if [ -n "$NEW_VERSION" ]; then
+            echo "new_release_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "last_release_version=$LAST_VERSION" >> $GITHUB_OUTPUT
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request modifies the semantic-release step in the GitHub Actions workflow to switch from using the `semantic-release` GitHub Action to a custom script. The change provides more control over the process and introduces version extraction logic.

Changes to the semantic-release step:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L67-R82): Replaced the `semantic-release/semantic-release@v24` action with a custom script that installs `semantic-release`, runs it in dry-run mode, extracts the new and last release versions, and sets them as GitHub Action outputs.