### PR TITLE
chore: further update workflows

### DIFF
--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -35,7 +35,7 @@ jobs:
         id: check-target-branch
         uses: actions/github-script@v6
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const prNumber = context.issue.number;

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -35,7 +35,7 @@ jobs:
         id: check-target-branch
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const prNumber = context.issue.number;

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -35,7 +35,7 @@ jobs:
         id: check-target-branch
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const prNumber = context.issue.number;

--- a/.github/workflows/promote-to-main.yml
+++ b/.github/workflows/promote-to-main.yml
@@ -22,7 +22,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          # Use deploy key for git operations to bypass branch protection
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       
       - name: Set Git identity
         run: |

--- a/.github/workflows/release-next-package.yml
+++ b/.github/workflows/release-next-package.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Use GH_TOKEN for both git operations and GitHub API
-          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          # Use deploy key for git operations to bypass branch protection
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -65,9 +65,8 @@ jobs:
 
       - name: Release
         env:
-          # Use GH_TOKEN for GitHub operations (both Git and API)
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          # Use GH_TOKEN for API operations (the git operations will use the deploy key)
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           # Use NPM_TOKEN for npm publishing
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/revalidate-pr.yml
+++ b/.github/workflows/revalidate-pr.yml
@@ -22,7 +22,7 @@ jobs:
         id: pr_info
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
           script: |
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
@@ -40,7 +40,7 @@ jobs:
       - name: Add comment to PR
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
           script: |
             const prInfo = ${{ steps.pr_info.outputs.result }};
             

--- a/.github/workflows/revalidate-pr.yml
+++ b/.github/workflows/revalidate-pr.yml
@@ -22,7 +22,7 @@ jobs:
         id: pr_info
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
@@ -40,7 +40,7 @@ jobs:
       - name: Add comment to PR
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const prInfo = ${{ steps.pr_info.outputs.result }};
             

--- a/.github/workflows/revalidate-pr.yml
+++ b/.github/workflows/revalidate-pr.yml
@@ -22,7 +22,7 @@ jobs:
         id: pr_info
         uses: actions/github-script@v6
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
@@ -40,7 +40,7 @@ jobs:
       - name: Add comment to PR
         uses: actions/github-script@v6
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const prInfo = ${{ steps.pr_info.outputs.result }};
             

--- a/README.md
+++ b/README.md
@@ -15,23 +15,23 @@
 <div align="center">
 
 ### Project Status
-[![Latest Release](https://github.com/zjayers/assemblejs/badges/release.svg)](https://github.com/zjayers/assemblejs/releases)
+[![npm version](https://img.shields.io/npm/v/asmbl)](https://www.npmjs.com/package/asmbl)
 [![npm bundle size](https://img.shields.io/bundlephobia/minzip/asmbl)](https://bundlephobia.com/package/asmbl)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ### Quality
-[![pipeline status](https://github.com/zjayers/assemblejs/badges/master/pipeline.svg)](https://github.com/zjayers/assemblejs/commits/master)
-[![coverage report](https://github.com/zjayers/assemblejs/badges/master/coverage.svg)](https://github.com/zjayers/assemblejs/commits/master)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/zjayers/assemblejs/pr-validation.yml?branch=main)](https://github.com/zjayers/assemblejs/actions/workflows/pr-validation.yml)
+[![GitHub issues](https://img.shields.io/github/issues/zjayers/assemblejs)](https://github.com/zjayers/assemblejs/issues)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 ### Technology
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![Node.js](https://img.shields.io/badge/Node.js->=18-success?logo=node.js&logoColor=white)](https://nodejs.org)
+[![Node.js](https://img.shields.io/badge/Node.js-%3E%3D18-success?logo=node.js&logoColor=white)](https://nodejs.org)
 
 ### Community
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./DOCUMENTATION.md#contributing-to-assemblejs)
 [![Support](https://img.shields.io/badge/Support-AssembleJS-blue)](https://github.com/sponsors/zjayers)
-[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 </div>


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to improve security and ensure compliance with branch protection rules by replacing the use of `GITHUB_TOKEN` with `GH_TOKEN` for API operations and introducing `DEPLOY_KEY` for git operations. The changes also include updates to environment variables for clarity and consistency.

### Security and token updates:

* [`.github/workflows/pr-target-check.yml`](diffhunk://#diff-8a38fa9b0ed3b672d4732afb619cda07b54fbeb035e03a517d5f7145bac55190L38-R38): Replaced `GITHUB_TOKEN` with `GH_TOKEN` for API operations to align with updated token usage policies.
* [`.github/workflows/revalidate-pr.yml`](diffhunk://#diff-3e3ac0e7a8e6aacae6a5e38be47ac68ec8d65c3a4cd53f7a5b369f167dd59f9dL25-R25): Updated both API-related steps to use `GH_TOKEN` instead of `GITHUB_TOKEN`. [[1]](diffhunk://#diff-3e3ac0e7a8e6aacae6a5e38be47ac68ec8d65c3a4cd53f7a5b369f167dd59f9dL25-R25) [[2]](diffhunk://#diff-3e3ac0e7a8e6aacae6a5e38be47ac68ec8d65c3a4cd53f7a5b369f167dd59f9dL43-R43)

### Branch protection compliance:

* [`.github/workflows/promote-to-main.yml`](diffhunk://#diff-ab79e866909c814a043b3c53326edc7127e75a101feb211956dac205b57a5534L25-R26): Switched from using `GH_TOKEN`/`GITHUB_TOKEN` for git operations to using `DEPLOY_KEY` (SSH key) to bypass branch protection rules.
* [`.github/workflows/release-next-package.yml`](diffhunk://#diff-dbbe5a21298fbb66a76fd677718692151ff058037792af71e7bfc746a229a134L26-R27): Replaced `GH_TOKEN`/`GITHUB_TOKEN` with `DEPLOY_KEY` for git operations and retained `GH_TOKEN` for API operations, ensuring separation of concerns. [[1]](diffhunk://#diff-dbbe5a21298fbb66a76fd677718692151ff058037792af71e7bfc746a229a134L26-R27) [[2]](diffhunk://#diff-dbbe5a21298fbb66a76fd677718692151ff058037792af71e7bfc746a229a134L68-R69)