### PR TITLE
chore: deploy testing

### DIFF
--- a/.github/workflows/deploy-next-version.yml
+++ b/.github/workflows/deploy-next-version.yml
@@ -219,30 +219,9 @@ jobs:
                 if [ -f "../../../.github/docker/Dockerfile.testbed" ]; then
                   cp "../../../.github/docker/Dockerfile.testbed" "./Dockerfile"
                 else
-                  echo "⚠️ Shared Dockerfile not found, creating default"
-                  cat > Dockerfile << 'EOF'
-FROM node:20-alpine
-
-WORKDIR /app
-
-# Copy package files
-COPY package*.json ./
-
-# Install dependencies
-RUN npm install asmbl@next
-
-# Copy source code
-COPY . .
-
-# Build the application
-RUN npm run build
-
-# Expose port
-EXPOSE 3000
-
-# Start the application
-CMD ["node", "dist/server.js"]
-EOF
+                  echo "::error::Shared Dockerfile template not found at .github/docker/Dockerfile.testbed"
+                  echo "::error::Please create the Dockerfile template before deploying"
+                  exit 1
                 fi
               fi
               


### PR DESCRIPTION
This pull request modifies the deployment workflow to improve error handling when a shared Dockerfile template is missing. Instead of creating a default Dockerfile, the workflow now logs error messages and exits.

### Changes to deployment workflow:

* [`.github/workflows/deploy-next-version.yml`](diffhunk://#diff-4a7d92e061b4ab6fc9cbbaef01035ec463c21df2fe5a1f7ce32a68259cea8808L222-R224): Replaced the logic for creating a default Dockerfile with error messages and an early exit if the shared Dockerfile template (`.github/docker/Dockerfile.testbed`) is not found. This ensures that deployments fail explicitly when the required template is missing.