### PR TITLE
chore: deploy testing

### DIFF
--- a/.github/workflows/deploy-main-version.yml
+++ b/.github/workflows/deploy-main-version.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Install website dependencies
         run: cd websites/www.assemblejs.com && npm ci
       
-      - name: Build main package
-        run: npm run build
+      - name: Build and pack main package
+        run: npm pack
       
       - name: Cache build artifacts
         uses: actions/cache/save@v4
@@ -53,6 +53,7 @@ jobs:
             lib/
             websites/www.assemblejs.com/build/
             docs/
+            *.tgz
           key: ${{ env.cache-key }}
           enableCrossOsArchive: true
   
@@ -74,9 +75,6 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
       
-      - name: Install dependencies
-        run: npm ci --include=dev
-      
       - name: Restore build artifacts
         uses: actions/cache/restore@v4
         with:
@@ -84,6 +82,7 @@ jobs:
             lib/
             websites/www.assemblejs.com/build/
             docs/
+            *.tgz
           key: ${{ env.cache-key }}
           fail-on-cache-miss: true
       
@@ -91,7 +90,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm publish --tag latest
+          npm publish *.tgz --tag latest
           echo "Published package to npm with tag: latest"
   
   # Deploy website to S3 production bucket

--- a/.github/workflows/deploy-main-version.yml
+++ b/.github/workflows/deploy-main-version.yml
@@ -44,7 +44,11 @@ jobs:
         run: cd websites/www.assemblejs.com && npm ci
       
       - name: Build and pack main package
-        run: npm pack
+        run: |
+          # Run npm pack and capture the filename
+          PACKAGE_TGZ=$(npm pack | tail -n 1)
+          echo "Generated package: $PACKAGE_TGZ"
+          echo "PACKAGE_TGZ=$PACKAGE_TGZ" >> $GITHUB_ENV
       
       - name: Cache build artifacts
         uses: actions/cache/save@v4
@@ -90,8 +94,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm publish *.tgz --tag latest
-          echo "Published package to npm with tag: latest"
+          npm publish "$PACKAGE_TGZ" --tag latest
+          echo "Published package $PACKAGE_TGZ to npm with tag: latest"
   
   # Deploy website to S3 production bucket
   deploy-website:

--- a/.github/workflows/deploy-next-version.yml
+++ b/.github/workflows/deploy-next-version.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install website dependencies
         run: cd websites/www.assemblejs.com && npm ci
       
-      - name: Build main package
+      - name: Build and pack main package
         run: npm pack
       
       - name: Install Testbed dependencies
@@ -60,6 +60,7 @@ jobs:
             websites/www.assemblejs.com/build/
             testbed/*/dist/
             docs/
+            *.tgz
           key: ${{ env.cache-key }}
           enableCrossOsArchive: true
   
@@ -81,9 +82,6 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
       
-      - name: Install dependencies
-        run: npm ci --include=dev
-      
       - name: Restore build artifacts
         uses: actions/cache/restore@v4
         with:
@@ -92,6 +90,7 @@ jobs:
             websites/www.assemblejs.com/build/
             testbed/*/dist/
             docs/
+            *.tgz
           key: ${{ env.cache-key }}
           fail-on-cache-miss: true
       
@@ -99,7 +98,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm publish --tag next
+          npm publish *.tgz --tag next
           echo "Published package to npm with tag: next"
   
   # Deploy website to S3 next bucket

--- a/.github/workflows/deploy-next-version.yml
+++ b/.github/workflows/deploy-next-version.yml
@@ -44,7 +44,11 @@ jobs:
         run: cd websites/www.assemblejs.com && npm ci
       
       - name: Build and pack main package
-        run: npm pack
+        run: |
+          # Run npm pack and capture the filename
+          PACKAGE_TGZ=$(npm pack | tail -n 1)
+          echo "Generated package: $PACKAGE_TGZ"
+          echo "PACKAGE_TGZ=$PACKAGE_TGZ" >> $GITHUB_ENV
       
       - name: Install Testbed dependencies
         run: npm run testbed:install
@@ -98,8 +102,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm publish *.tgz --tag next
-          echo "Published package to npm with tag: next"
+          npm publish "$PACKAGE_TGZ" --tag next
+          echo "Published package $PACKAGE_TGZ to npm with tag: next"
   
   # Deploy website to S3 next bucket
   deploy-website:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 
 ---
 
-<!-- TOC -->
-
 ## Index
 
 - [Index](#index)


### PR DESCRIPTION
This pull request updates the deployment workflows for the main and next versions to improve the package publishing process by switching to using pre-packed `.tgz` files. Additionally, it removes an unused section in the `README.md`. Below are the most important changes grouped by theme:

### Workflow Improvements

* Updated the `deploy-main-version.yml` workflow to replace the build step with a `npm pack` command, cache the generated `.tgz` file, and use it for publishing to npm with the `--tag latest` option. (`.github/workflows/deploy-main-version.yml`) [[1]](diffhunk://#diff-aa11f5a47f9a370bf1243b1ad11dd03b84898e36b0b33b1bb0614501c5bb779bL46-R47) [[2]](diffhunk://#diff-aa11f5a47f9a370bf1243b1ad11dd03b84898e36b0b33b1bb0614501c5bb779bR56) [[3]](diffhunk://#diff-aa11f5a47f9a370bf1243b1ad11dd03b84898e36b0b33b1bb0614501c5bb779bL77-R93)
* Updated the `deploy-next-version.yml` workflow similarly to use `npm pack`, cache the `.tgz` file, and publish it to npm with the `--tag next` option. (`.github/workflows/deploy-next-version.yml`) [[1]](diffhunk://#diff-4a7d92e061b4ab6fc9cbbaef01035ec463c21df2fe5a1f7ce32a68259cea8808L46-R46) [[2]](diffhunk://#diff-4a7d92e061b4ab6fc9cbbaef01035ec463c21df2fe5a1f7ce32a68259cea8808R63) [[3]](diffhunk://#diff-4a7d92e061b4ab6fc9cbbaef01035ec463c21df2fe5a1f7ce32a68259cea8808L84-L86) [[4]](diffhunk://#diff-4a7d92e061b4ab6fc9cbbaef01035ec463c21df2fe5a1f7ce32a68259cea8808R93-R101)

### Documentation Cleanup

* Removed an unused "Table of Contents" comment block from the `README.md` file. (`README.md`)